### PR TITLE
Hotfix: Remove a problematic XML tag from the index

### DIFF
--- a/minirepo.py
+++ b/minirepo.py
@@ -66,7 +66,11 @@ def get_names():
     # resp = urllib2.urlopen('https://pypi.python.org/simple')
     # tree = ElementTree.parse(resp)
     resp = requests.get('https://pypi.python.org/simple')
-    tree = ElementTree.fromstring(resp.content)
+    tree = ElementTree.fromstring(
+		# Hotfix because the XML parser has issues with this specific tag, we remove it from the input
+		# TODO: A different XML parser might have less issues, see if this can be fixed properly
+		resp.content.replace(b'<meta name="pypi:repository-version" content="1.1">', b'')
+	)
     return [a.text for a in tree.iter('a')]
 
 def get_chunks(seq, num):


### PR DESCRIPTION
I like this project! However, when I started it, it had some issues with one of the XML tags in the PyPI simple package index. As a hotfix I decided to remove this tag from the input. Probably a better way to address this is by switching to an XML parser that doesn't have this issue.