### PR TITLE
Make path to config file configurable using an environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,12 @@ The first time it's executed, the program will ask you for the local repository 
         	"platforms"	  : ["linux"]
 	}
 
+The location of the configuration file and the repository can be set by environment variables:
+
+.. code::
+
+MINIREPO_CONFIG="./minirepo_conf.json" MINIREPO_REPO="~/tmp/minirepo" ./minirepo.py
+
 
 Minirepo uses packages_types, extensions, platforms and python_versions as filters. I was analysing the full list of packages available in pypi.python.org_, and it looks that all the options are something like the list below, you can try any other option. For me, I was only interested in python 2.7 packages, sources, wheels and eegs distributions, and some extensions.
 

--- a/minirepo.py
+++ b/minirepo.py
@@ -264,35 +264,35 @@ def worker(args):
 	return (pid, packages_downloaded, bytes_downloaded, bytes_cleaned)
 
 def get_config():
-        config_file = os.path.expanduser("~/.minirepo")
-        repository = os.path.expanduser("~/minirepo")
-        processes = PROCESSES
-        try:
-                with open(config_file, 'r') as f:
-                    config = json.load(f)
-        except (json.JSONDecodeError, FileNotFoundError):
-                newrepo = input(f'Repository folder [{repository}]: ')
-                if newrepo:
-                        repository = newrepo
-                newprocesses = input(f'Number of processes [{processes}]: ')
-                if newprocesses:
-                        processes = int(newprocesses)
-                config = {
-					"repository": repository,
-					"processes": processes,
-					"python_versions":PYTHON_VERSIONS,
-					"package_types": PACKAGE_TYPES,
-					"extensions": EXTENSIONS,
-					"platforms": PLATFORMS,
-                }
-                with open(config_file, 'w') as w:
-                        json.dump(config, w, indent=2)
+	config_file = os.path.expanduser("~/.minirepo")
+	repository = os.path.expanduser("~/minirepo")
+	processes = PROCESSES
+	try:
+		with open(config_file, 'r') as f:
+			config = json.load(f)
+	except (json.JSONDecodeError, FileNotFoundError):
+		newrepo = input(f'Repository folder [{repository}]: ')
+		if newrepo:
+			repository = newrepo
+		newprocesses = input(f'Number of processes [{processes}]: ')
+		if newprocesses:
+			processes = int(newprocesses)
+		config = {
+			"repository": repository,
+			"processes": processes,
+			"python_versions":PYTHON_VERSIONS,
+			"package_types": PACKAGE_TYPES,
+			"extensions": EXTENSIONS,
+			"platforms": PLATFORMS,
+		}
+		with open(config_file, 'w') as w:
+			json.dump(config, w, indent=2)
 
-        for c in sorted(config):
-                print('%-15s = %s' % (c,config[c]))
-        print('Using config file %s ' % config_file)
+	for c in sorted(config):
+		print('%-15s = %s' % (c,config[c]))
+	print('Using config file %s ' % config_file)
 
-        return config
+	return config
 
 def save_json(pids):
 	# concatenate output from each worker

--- a/minirepo.py
+++ b/minirepo.py
@@ -263,9 +263,12 @@ def worker(args):
 	
 	return (pid, packages_downloaded, bytes_downloaded, bytes_cleaned)
 
-def get_config():
-	config_file = os.path.expanduser("~/.minirepo")
+def get_config(config_file):
+	config_file = config_file
+
+	# Default repository path (only used if the config file does not exit)
 	repository = os.path.expanduser("~/minirepo")
+
 	processes = PROCESSES
 	try:
 		with open(config_file, 'r') as f:
@@ -326,8 +329,12 @@ def main(repository='', processes=0):
 	
 	print('/******** Minirepo ********/')
 	
-	# get configuraiton values
-	config 			= get_config()
+	# get configuration values
+
+	config_file = os.path.expanduser(
+		path=os.environ.get("MINIREPO_CONFIG", "~/.minirepo"))
+
+	config 			= get_config(config_file=config_file)
 	REPOSITORY		= config["repository"]
 	PROCESSES		= config["processes"]
 	PYTHON_VERSIONS	= config["python_versions"]


### PR DESCRIPTION
It can be useful to be able to start minirepo from a config file that is not in ~/.minirepo. This add an optional environment variable MINIREPO_CONFIG that will overide the default path.
