### PR TITLE
Allow relative path for repo in the config

### DIFF
--- a/minirepo.py
+++ b/minirepo.py
@@ -264,35 +264,35 @@ def worker(args):
 	return (pid, packages_downloaded, bytes_downloaded, bytes_cleaned)
 
 def get_config():
-        config_file = os.path.expanduser("~/.minirepo")
-        repository = os.path.expanduser("~/minirepo")
-        processes = PROCESSES
-        try:
-                with open(config_file, 'r') as f:
-                    config = json.load(f)
-        except (json.JSONDecodeError, FileNotFoundError):
-                newrepo = input(f'Repository folder [{repository}]: ')
-                if newrepo:
-                        repository = newrepo
-                newprocesses = input(f'Number of processes [{processes}]: ')
-                if newprocesses:
-                        processes = int(newprocesses)
-                config = {
-					"repository": repository,
-					"processes": processes,
-					"python_versions":PYTHON_VERSIONS,
-					"package_types": PACKAGE_TYPES,
-					"extensions": EXTENSIONS,
-					"platforms": PLATFORMS,
-                }
-                with open(config_file, 'w') as w:
-                        json.dump(config, w, indent=2)
+	config_file = os.path.expanduser("~/.minirepo")
+	repository = os.path.expanduser("~/minirepo")
+	processes = PROCESSES
+	try:
+		with open(config_file, 'r') as f:
+			config = json.load(f)
+	except (json.JSONDecodeError, FileNotFoundError):
+		newrepo = input(f'Repository folder [{repository}]: ')
+		if newrepo:
+			repository = newrepo
+		newprocesses = input(f'Number of processes [{processes}]: ')
+		if newprocesses:
+			processes = int(newprocesses)
+		config = {
+			"repository": repository,
+			"processes": processes,
+			"python_versions":PYTHON_VERSIONS,
+			"package_types": PACKAGE_TYPES,
+			"extensions": EXTENSIONS,
+			"platforms": PLATFORMS,
+		}
+		with open(config_file, 'w') as w:
+			json.dump(config, w, indent=2)
 
-        for c in sorted(config):
-                print('%-15s = %s' % (c,config[c]))
-        print('Using config file %s ' % config_file)
+	for c in sorted(config):
+		print('%-15s = %s' % (c,config[c]))
+	print('Using config file %s ' % config_file)
 
-        return config
+	return config
 
 def save_json(pids):
 	# concatenate output from each worker

--- a/minirepo.py
+++ b/minirepo.py
@@ -326,9 +326,9 @@ def main(repository='', processes=0):
 	
 	print('/******** Minirepo ********/')
 	
-	# get configuraiton values
+	# get configuration values
 	config 			= get_config()
-	REPOSITORY		= config["repository"]
+	REPOSITORY		= os.path.expanduser(config["repository"])
 	PROCESSES		= config["processes"]
 	PYTHON_VERSIONS	= config["python_versions"]
 	PACKAGE_TYPES	= config["package_types"]


### PR DESCRIPTION
Sometimes it is useful to have a repo path defined in the config file that is relative to the users home directory rather than an obsolute path. This just adds path expansion when reading the repository path from the config file.